### PR TITLE
Update angular-backstretch.js

### DIFF
--- a/angular-backstretch.js
+++ b/angular-backstretch.js
@@ -1,9 +1,9 @@
 angular.module('backstretch')
 	.directive('backstretch', function () {
 		return {
-			restrict: 'A'
+			restrict: 'A',
 			link: function (scope, element, attr) {
-				$(element).backstretch(attr.backgroundUrl);
+				element.backstretch(attr.backgroundUrl);
 			}
 		}
 	});


### PR DESCRIPTION
Need a comma between properties, and element is already jQuery-ized so we don't need $()
